### PR TITLE
fix: non-static maximum value

### DIFF
--- a/src/app/gauge/gauge.component.ts
+++ b/src/app/gauge/gauge.component.ts
@@ -48,7 +48,12 @@ export class GaugeComponent implements OnInit, AfterViewInit, GaugeProps {
   @Input()
   set input(val: number) {
     this._input = val;
+    this.scaleLines = [];
+    this.scaleValues = [];
     this._updateArrowPos(val);
+    this._calculateSectors();
+    this.scaleFactor = this.factor || this._determineScaleFactor();
+    this._createScale();
   }
 
   get input(): number {


### PR DESCRIPTION
I was using the component, but in my situation the maximum value could not be static.
When you updated the maximum value, the chart did not render again.

I modified the component code and got it fixed, but I'm sure I will not be the only one facing this problem.

The problem is in the file: gauge.component.ts, at line 49.

was like this:

@input()
set input(val: number) {
this._input = val;
this._updateArrowPos(val);
}

modified to:

@input()
set input(val: number) {
this._input = val;
this.scaleLines = [];
this.scaleValues = [];
this._updateArrowPos(val);
this._calculateSectors();
this.scaleFactor = this.factor || this._determineScaleFactor();
this._createScale();
}